### PR TITLE
Jenkins support

### DIFF
--- a/src/main/java/eu/stamp_project/testrunner/EntryPoint.java
+++ b/src/main/java/eu/stamp_project/testrunner/EntryPoint.java
@@ -8,6 +8,7 @@ import eu.stamp_project.testrunner.runner.test.TestRunner;
 import org.apache.commons.io.FileUtils;
 import org.jacoco.core.runtime.IRuntime;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.xml.Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -454,7 +455,8 @@ public class EntryPoint {
 
     private static final List<Class<?>> JACOCO_DEPENDENCIES = Arrays.asList(
             IRuntime.class,
-            Type.class,
+            // Type.class,
+            Processor.class,
             FileUtils.class
     );
 


### PR DESCRIPTION
the Type class is also present in a ASM lib shipped with Jenkins, the change avoids the wrong jar to be added in the classpath of Jacoco dependencies.