### PR TITLE
Add synchronized to methods to avoid serialization issues during concurrent thread access

### DIFF
--- a/src/main/java/eu/stamp_project/testrunner/listener/junit4/CoveragePerJUnit4TestMethod.java
+++ b/src/main/java/eu/stamp_project/testrunner/listener/junit4/CoveragePerJUnit4TestMethod.java
@@ -54,7 +54,7 @@ public class CoveragePerJUnit4TestMethod extends JUnit4TestResult implements Cov
             parametrizedName.contains("[") ? parametrizedName.split("\\[")[0] : parametrizedName;
 
     @Override
-    public void testStarted(Description description) throws Exception {
+    public synchronized void testStarted(Description description) throws Exception {
         this.internalCoverage.setExecutionData(new ExecutionDataStore());
         this.internalCoverage.setSessionInfos(new SessionInfoStore());
         this.internalCoverage.getData().setSessionId(description.getMethodName());
@@ -66,7 +66,7 @@ public class CoveragePerJUnit4TestMethod extends JUnit4TestResult implements Cov
     }
 
     @Override
-    public void testFinished(Description description) throws Exception {
+    public synchronized void testFinished(Description description) throws Exception {
         this.internalCoverage.getData().collect(
                 this.internalCoverage.getExecutionData(),
                 this.internalCoverage.getSessionInfos(),

--- a/src/main/java/eu/stamp_project/testrunner/listener/junit5/CoveragePerJUnit5TestMethod.java
+++ b/src/main/java/eu/stamp_project/testrunner/listener/junit5/CoveragePerJUnit5TestMethod.java
@@ -34,7 +34,7 @@ public class CoveragePerJUnit5TestMethod extends JUnit5TestResult implements Cov
     }
 
     @Override
-    public void executionStarted(TestIdentifier testIdentifier) {
+    public synchronized void executionStarted(TestIdentifier testIdentifier) {
         if (testIdentifier.isTest()) {
             this.internalCoverage.setExecutionData(new ExecutionDataStore());
             this.internalCoverage.setSessionInfos(new SessionInfoStore());
@@ -49,7 +49,7 @@ public class CoveragePerJUnit5TestMethod extends JUnit5TestResult implements Cov
     }
 
     @Override
-    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+    public synchronized void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
         if (testIdentifier.isTest()) {
             this.internalCoverage.getData().collect(
                     this.internalCoverage.getExecutionData(),


### PR DESCRIPTION
Add synchronized to methods to avoid serialization issues during concurrent thread access when coverage is computed. This is required to avoid some NPE after reading the computed coverage in DSpot parallel execution